### PR TITLE
Update libopencm3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libopencm3"]
+	path = libopencm3
+	url = https://github.com/libopencm3/libopencm3

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all clean
 
-DIRS=aes128 aes128ctr aes192ctr aes256ctr aes128ctrbs aes128ctrbsmasked
+DIRS=libopencm3 aes128 aes128ctr aes192ctr aes256ctr aes128ctrbs aes128ctrbsmasked
 COMMONDIR=common
 
 all clean:

--- a/aes128/Makefile
+++ b/aes128/Makefile
@@ -7,7 +7,7 @@ OBJCOPY	= $(PREFIX)-objcopy
 OBJDUMP	= $(PREFIX)-objdump
 GDB		= $(PREFIX)-gdb
 
-OPENCM3DIR = /usr/arm-none-eabi
+OPENCM3DIR = ../libopencm3/
 ARMNONEEABIDIR = /usr/arm-none-eabi
 COMMONDIR = ../common
 
@@ -37,7 +37,7 @@ CFLAGS		+= -O3 \
 		   -fno-common $(ARCH_FLAGS) -MD
 LDFLAGS		+= --static -Wl,--start-group -lc -lgcc -lnosys -Wl,--end-group \
 		   -T$(LDSCRIPT) -nostartfiles -Wl,--gc-sections,--no-print-gc-sections \
-		   $(ARCH_FLAGS)
+		   $(ARCH_FLAGS) -L$(OPENCM3DIR)/lib
 
 OBJS		+= aes.s
 

--- a/aes128/Makefile
+++ b/aes128/Makefile
@@ -7,7 +7,7 @@ OBJCOPY	= $(PREFIX)-objcopy
 OBJDUMP	= $(PREFIX)-objdump
 GDB		= $(PREFIX)-gdb
 
-OPENCM3DIR = ../libopencm3/
+OPENCM3DIR = ../libopencm3
 ARMNONEEABIDIR = /usr/arm-none-eabi
 COMMONDIR = ../common
 
@@ -17,17 +17,17 @@ aes_m4.%: ARCH_FLAGS = -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d1
 aes_m4.o: CFLAGS += -DSTM32F4
 $(COMMONDIR)/stm32f4_wrapper.o: CFLAGS += -DSTM32F4
 aes_m4.elf: LDSCRIPT = $(COMMONDIR)/stm32f407x6.ld
-aes_m4.elf: LDFLAGS += -L$(OPENCM3DIR)/lib/armv7e-m/fpu -lopencm3_stm32f4
+aes_m4.elf: LDFLAGS += -lopencm3_stm32f4
 aes_m4.elf: OBJS += $(COMMONDIR)/stm32f4_wrapper.o 
-aes_m4.elf: $(COMMONDIR)/stm32f4_wrapper.o $(OPENCM3DIR)/lib/libopencm3_stm32f4.a
+aes_m4.elf: $(COMMONDIR)/stm32f4_wrapper.o
 
 aes_m3.%: ARCH_FLAGS = -mthumb -mcpu=cortex-m3 -msoft-float
 aes_m3.o: CFLAGS += -DSTM32L1
 $(COMMONDIR)/stm32l1_wrapper.o: CFLAGS += -DSTM32L1
 aes_m3.elf: LDSCRIPT = $(COMMONDIR)/stm32l100xc.ld
-aes_m3.elf: LDFLAGS += -L$(OPENCM3DIR)/lib/armv7-m -lopencm3_stm32l1
+aes_m3.elf: LDFLAGS += -lopencm3_stm32l1
 aes_m3.elf: OBJS += $(COMMONDIR)/stm32l1_wrapper.o 
-aes_m3.elf: $(COMMONDIR)/stm32l1_wrapper.o $(OPENCM3DIR)/lib/libopencm3_stm32l1.a
+aes_m3.elf: $(COMMONDIR)/stm32l1_wrapper.o
 
 CFLAGS		+= -O3 \
 		   -Wall -Wextra -Wimplicit-function-declaration \

--- a/aes128ctr/Makefile
+++ b/aes128ctr/Makefile
@@ -7,7 +7,7 @@ OBJCOPY	= $(PREFIX)-objcopy
 OBJDUMP	= $(PREFIX)-objdump
 GDB		= $(PREFIX)-gdb
 
-OPENCM3DIR = ../libopencm3/
+OPENCM3DIR = ../libopencm3
 ARMNONEEABIDIR = /usr/arm-none-eabi
 COMMONDIR = ../common
 
@@ -17,17 +17,17 @@ aes_128_ctr_m4.%: ARCH_FLAGS = -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fp
 aes_128_ctr_m4.o: CFLAGS += -DSTM32F4
 $(COMMONDIR)/stm32f4_wrapper.o: CFLAGS += -DSTM32F4
 aes_128_ctr_m4.elf: LDSCRIPT = $(COMMONDIR)/stm32f407x6.ld
-aes_128_ctr_m4.elf: LDFLAGS += -L$(OPENCM3DIR)/lib/armv7e-m/fpu -lopencm3_stm32f4
+aes_128_ctr_m4.elf: LDFLAGS += -lopencm3_stm32f4
 aes_128_ctr_m4.elf: OBJS += $(COMMONDIR)/stm32f4_wrapper.o 
-aes_128_ctr_m4.elf: $(COMMONDIR)/stm32f4_wrapper.o $(OPENCM3DIR)/lib/libopencm3_stm32f4.a
+aes_128_ctr_m4.elf: $(COMMONDIR)/stm32f4_wrapper.o
 
 aes_128_ctr_m3.%: ARCH_FLAGS = -mthumb -mcpu=cortex-m3 -msoft-float
 aes_128_ctr_m3.o: CFLAGS += -DSTM32L1
 $(COMMONDIR)/stm32l1_wrapper.o: CFLAGS += -DSTM32L1
 aes_128_ctr_m3.elf: LDSCRIPT = $(COMMONDIR)/stm32l100xc.ld
-aes_128_ctr_m3.elf: LDFLAGS += -L$(OPENCM3DIR)/lib/armv7-m -lopencm3_stm32l1
+aes_128_ctr_m3.elf: LDFLAGS += -lopencm3_stm32l1
 aes_128_ctr_m3.elf: OBJS += $(COMMONDIR)/stm32l1_wrapper.o 
-aes_128_ctr_m3.elf: $(COMMONDIR)/stm32l1_wrapper.o $(OPENCM3DIR)/lib/libopencm3_stm32l1.a
+aes_128_ctr_m3.elf: $(COMMONDIR)/stm32l1_wrapper.o
 
 CFLAGS		+= -O3 \
 		   -Wall -Wextra -Wimplicit-function-declaration \

--- a/aes128ctr/Makefile
+++ b/aes128ctr/Makefile
@@ -7,7 +7,7 @@ OBJCOPY	= $(PREFIX)-objcopy
 OBJDUMP	= $(PREFIX)-objdump
 GDB		= $(PREFIX)-gdb
 
-OPENCM3DIR = /usr/arm-none-eabi
+OPENCM3DIR = ../libopencm3/
 ARMNONEEABIDIR = /usr/arm-none-eabi
 COMMONDIR = ../common
 
@@ -37,7 +37,7 @@ CFLAGS		+= -O3 \
 		   -fno-common $(ARCH_FLAGS) -MD
 LDFLAGS		+= --static -Wl,--start-group -lc -lgcc -lnosys -Wl,--end-group \
 		   -T$(LDSCRIPT) -nostartfiles -Wl,--gc-sections,--no-print-gc-sections \
-		   $(ARCH_FLAGS)
+		   $(ARCH_FLAGS) -L$(OPENCM3DIR)/lib
 
 OBJS		+= aes_128_ctr.s
 

--- a/aes128ctrbs/Makefile
+++ b/aes128ctrbs/Makefile
@@ -7,7 +7,7 @@ OBJCOPY	= $(PREFIX)-objcopy
 OBJDUMP	= $(PREFIX)-objdump
 GDB		= $(PREFIX)-gdb
 
-OPENCM3DIR = /usr/arm-none-eabi
+OPENCM3DIR = ../libopencm3/
 ARMNONEEABIDIR = /usr/arm-none-eabi
 COMMONDIR = ../common
 
@@ -37,7 +37,7 @@ CFLAGS		+= -O3 \
 		   -fno-common $(ARCH_FLAGS) -MD
 LDFLAGS		+= --static -Wl,--start-group -lc -lgcc -lnosys -Wl,--end-group \
 		   -T$(LDSCRIPT) -nostartfiles -Wl,--gc-sections,--no-print-gc-sections \
-		   $(ARCH_FLAGS)
+		   $(ARCH_FLAGS) -L$(OPENCM3DIR)/lib
 
 OBJS		+= aes_128_ctr_bs.s
 

--- a/aes128ctrbs/Makefile
+++ b/aes128ctrbs/Makefile
@@ -7,7 +7,7 @@ OBJCOPY	= $(PREFIX)-objcopy
 OBJDUMP	= $(PREFIX)-objdump
 GDB		= $(PREFIX)-gdb
 
-OPENCM3DIR = ../libopencm3/
+OPENCM3DIR = ../libopencm3
 ARMNONEEABIDIR = /usr/arm-none-eabi
 COMMONDIR = ../common
 
@@ -17,17 +17,17 @@ aes_128_ctr_bs_m4.%: ARCH_FLAGS = -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu
 aes_128_ctr_bs_m4.o: CFLAGS += -DSTM32F4
 $(COMMONDIR)/stm32f4_wrapper.o: CFLAGS += -DSTM32F4
 aes_128_ctr_bs_m4.elf: LDSCRIPT = $(COMMONDIR)/stm32f407x6.ld
-aes_128_ctr_bs_m4.elf: LDFLAGS += -L$(OPENCM3DIR)/lib/armv7e-m/fpu -lopencm3_stm32f4
+aes_128_ctr_bs_m4.elf: LDFLAGS += -lopencm3_stm32f4
 aes_128_ctr_bs_m4.elf: OBJS += $(COMMONDIR)/stm32f4_wrapper.o
-aes_128_ctr_bs_m4.elf: $(COMMONDIR)/stm32f4_wrapper.o $(OPENCM3DIR)/lib/libopencm3_stm32f4.a
+aes_128_ctr_bs_m4.elf: $(COMMONDIR)/stm32f4_wrapper.o
 
 aes_128_ctr_bs_m3.%: ARCH_FLAGS = -mthumb -mcpu=cortex-m3 -msoft-float
 aes_128_ctr_bs_m3.o: CFLAGS += -DSTM32L1
 $(COMMONDIR)/stm32l1_wrapper.o: CFLAGS += -DSTM32L1
 aes_128_ctr_bs_m3.elf: LDSCRIPT = $(COMMONDIR)/stm32l100xc.ld
-aes_128_ctr_bs_m3.elf: LDFLAGS += -L$(OPENCM3DIR)/lib/armv7-m -lopencm3_stm32l1
+aes_128_ctr_bs_m3.elf: LDFLAGS += -lopencm3_stm32l1
 aes_128_ctr_bs_m3.elf: OBJS += $(COMMONDIR)/stm32l1_wrapper.o
-aes_128_ctr_bs_m3.elf: $(COMMONDIR)/stm32l1_wrapper.o $(OPENCM3DIR)/lib/libopencm3_stm32l1.a
+aes_128_ctr_bs_m3.elf: $(COMMONDIR)/stm32l1_wrapper.o
 
 CFLAGS		+= -O3 \
 		   -Wall -Wextra -Wimplicit-function-declaration \

--- a/aes128ctrbsmasked/Makefile
+++ b/aes128ctrbsmasked/Makefile
@@ -7,7 +7,7 @@ OBJCOPY	= $(PREFIX)-objcopy
 OBJDUMP	= $(PREFIX)-objdump
 GDB		= $(PREFIX)-gdb
 
-OPENCM3DIR = /usr/arm-none-eabi
+OPENCM3DIR = ../libopencm3/
 ARMNONEEABIDIR = /usr/arm-none-eabi
 COMMONDIR = ../common
 
@@ -37,7 +37,7 @@ CFLAGS		+= -O3 \
 		   -fno-common $(ARCH_FLAGS) -MD
 LDFLAGS		+= --static -Wl,--start-group -lc -lgcc -lnosys -Wl,--end-group \
 		   -T$(LDSCRIPT) -nostartfiles -Wl,--gc-sections,--no-print-gc-sections \
-		   $(ARCH_FLAGS)
+		   $(ARCH_FLAGS) -L$(OPENCM3DIR)/lib
 
 OBJS		+= aes_128_ctr_bs_masked.s
 

--- a/aes128ctrbsmasked/Makefile
+++ b/aes128ctrbsmasked/Makefile
@@ -7,7 +7,7 @@ OBJCOPY	= $(PREFIX)-objcopy
 OBJDUMP	= $(PREFIX)-objdump
 GDB		= $(PREFIX)-gdb
 
-OPENCM3DIR = ../libopencm3/
+OPENCM3DIR = ../libopencm3
 ARMNONEEABIDIR = /usr/arm-none-eabi
 COMMONDIR = ../common
 
@@ -17,17 +17,17 @@ aes_128_ctr_bs_masked_m4.%: ARCH_FLAGS = -mthumb -mcpu=cortex-m4 -mfloat-abi=har
 aes_128_ctr_bs_masked_m4.o: CFLAGS += -DSTM32F4
 $(COMMONDIR)/stm32f4_wrapper.o: CFLAGS += -DSTM32F4
 aes_128_ctr_bs_masked_m4.elf: LDSCRIPT = $(COMMONDIR)/stm32f407x6.ld
-aes_128_ctr_bs_masked_m4.elf: LDFLAGS += -L$(OPENCM3DIR)/lib/armv7e-m/fpu -lopencm3_stm32f4
+aes_128_ctr_bs_masked_m4.elf: LDFLAGS += -lopencm3_stm32f4
 aes_128_ctr_bs_masked_m4.elf: OBJS += $(COMMONDIR)/stm32f4_wrapper.o
-aes_128_ctr_bs_masked_m4.elf: $(COMMONDIR)/stm32f4_wrapper.o $(OPENCM3DIR)/lib/libopencm3_stm32f4.a
+aes_128_ctr_bs_masked_m4.elf: $(COMMONDIR)/stm32f4_wrapper.o
 
 aes_128_ctr_bs_masked_m3.%: ARCH_FLAGS = -mthumb -mcpu=cortex-m3 -msoft-float
 aes_128_ctr_bs_masked_m3.o: CFLAGS += -DSTM32L1
 $(COMMONDIR)/stm32l1_wrapper.o: CFLAGS += -DSTM32L1
 aes_128_ctr_bs_masked_m3.elf: LDSCRIPT = $(COMMONDIR)/stm32l100xc.ld
-aes_128_ctr_bs_masked_m3.elf: LDFLAGS += -L$(OPENCM3DIR)/lib/armv7-m -lopencm3_stm32l1
+aes_128_ctr_bs_masked_m3.elf: LDFLAGS += -lopencm3_stm32l1
 aes_128_ctr_bs_masked_m3.elf: OBJS += $(COMMONDIR)/stm32l1_wrapper.o
-aes_128_ctr_bs_masked_m3.elf: $(COMMONDIR)/stm32l1_wrapper.o $(OPENCM3DIR)/lib/libopencm3_stm32l1.a
+aes_128_ctr_bs_masked_m3.elf: $(COMMONDIR)/stm32l1_wrapper.o
 
 CFLAGS		+= -O3 \
 		   -Wall -Wextra -Wimplicit-function-declaration \

--- a/aes192ctr/Makefile
+++ b/aes192ctr/Makefile
@@ -7,7 +7,7 @@ OBJCOPY	= $(PREFIX)-objcopy
 OBJDUMP	= $(PREFIX)-objdump
 GDB		= $(PREFIX)-gdb
 
-OPENCM3DIR = /usr/arm-none-eabi
+OPENCM3DIR = ../libopencm3/
 ARMNONEEABIDIR = /usr/arm-none-eabi
 COMMONDIR = ../common
 
@@ -37,7 +37,7 @@ CFLAGS		+= -O3 \
 		   -fno-common $(ARCH_FLAGS) -MD
 LDFLAGS		+= --static -Wl,--start-group -lc -lgcc -lnosys -Wl,--end-group \
 		   -T$(LDSCRIPT) -nostartfiles -Wl,--gc-sections,--no-print-gc-sections \
-		   $(ARCH_FLAGS)
+		   $(ARCH_FLAGS) -L$(OPENCM3DIR)/lib
 
 OBJS		+= aes_192_ctr.s
 

--- a/aes192ctr/Makefile
+++ b/aes192ctr/Makefile
@@ -7,7 +7,7 @@ OBJCOPY	= $(PREFIX)-objcopy
 OBJDUMP	= $(PREFIX)-objdump
 GDB		= $(PREFIX)-gdb
 
-OPENCM3DIR = ../libopencm3/
+OPENCM3DIR = ../libopencm3
 ARMNONEEABIDIR = /usr/arm-none-eabi
 COMMONDIR = ../common
 
@@ -17,17 +17,17 @@ aes_192_ctr_m4.%: ARCH_FLAGS = -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fp
 aes_192_ctr_m4.o: CFLAGS += -DSTM32F4
 $(COMMONDIR)/stm32f4_wrapper.o: CFLAGS += -DSTM32F4
 aes_192_ctr_m4.elf: LDSCRIPT = $(COMMONDIR)/stm32f407x6.ld
-aes_192_ctr_m4.elf: LDFLAGS += -L$(OPENCM3DIR)/lib/armv7e-m/fpu -lopencm3_stm32f4
+aes_192_ctr_m4.elf: LDFLAGS += -lopencm3_stm32f4
 aes_192_ctr_m4.elf: OBJS += $(COMMONDIR)/stm32f4_wrapper.o
-aes_192_ctr_m4.elf: $(COMMONDIR)/stm32f4_wrapper.o $(OPENCM3DIR)/lib/libopencm3_stm32f4.a
+aes_192_ctr_m4.elf: $(COMMONDIR)/stm32f4_wrapper.o
 
 aes_192_ctr_m3.%: ARCH_FLAGS = -mthumb -mcpu=cortex-m3 -msoft-float
 aes_192_ctr_m3.o: CFLAGS += -DSTM32L1
 $(COMMONDIR)/stm32l1_wrapper.o: CFLAGS += -DSTM32L1
 aes_192_ctr_m3.elf: LDSCRIPT = $(COMMONDIR)/stm32l100xc.ld
-aes_192_ctr_m3.elf: LDFLAGS += -L$(OPENCM3DIR)/lib/armv7-m -lopencm3_stm32l1
+aes_192_ctr_m3.elf: LDFLAGS += -lopencm3_stm32l1
 aes_192_ctr_m3.elf: OBJS += $(COMMONDIR)/stm32l1_wrapper.o
-aes_192_ctr_m3.elf: $(COMMONDIR)/stm32l1_wrapper.o $(OPENCM3DIR)/lib/libopencm3_stm32l1.a
+aes_192_ctr_m3.elf: $(COMMONDIR)/stm32l1_wrapper.o
 
 CFLAGS		+= -O3 \
 		   -Wall -Wextra -Wimplicit-function-declaration \

--- a/aes256ctr/Makefile
+++ b/aes256ctr/Makefile
@@ -7,7 +7,7 @@ OBJCOPY	= $(PREFIX)-objcopy
 OBJDUMP	= $(PREFIX)-objdump
 GDB		= $(PREFIX)-gdb
 
-OPENCM3DIR = /usr/arm-none-eabi
+OPENCM3DIR = ../libopencm3/
 ARMNONEEABIDIR = /usr/arm-none-eabi
 COMMONDIR = ../common
 
@@ -37,7 +37,7 @@ CFLAGS		+= -O3 \
 		   -fno-common $(ARCH_FLAGS) -MD
 LDFLAGS		+= --static -Wl,--start-group -lc -lgcc -lnosys -Wl,--end-group \
 		   -T$(LDSCRIPT) -nostartfiles -Wl,--gc-sections,--no-print-gc-sections \
-		   $(ARCH_FLAGS)
+		   $(ARCH_FLAGS) -L$(OPENCM3DIR)/lib
 
 OBJS		+= aes_256_ctr.s
 

--- a/aes256ctr/Makefile
+++ b/aes256ctr/Makefile
@@ -7,7 +7,7 @@ OBJCOPY	= $(PREFIX)-objcopy
 OBJDUMP	= $(PREFIX)-objdump
 GDB		= $(PREFIX)-gdb
 
-OPENCM3DIR = ../libopencm3/
+OPENCM3DIR = ../libopencm3
 ARMNONEEABIDIR = /usr/arm-none-eabi
 COMMONDIR = ../common
 
@@ -17,17 +17,17 @@ aes_256_ctr_m4.%: ARCH_FLAGS = -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fp
 aes_256_ctr_m4.o: CFLAGS += -DSTM32F4
 $(COMMONDIR)/stm32f4_wrapper.o: CFLAGS += -DSTM32F4
 aes_256_ctr_m4.elf: LDSCRIPT = $(COMMONDIR)/stm32f407x6.ld
-aes_256_ctr_m4.elf: LDFLAGS += -L$(OPENCM3DIR)/lib/armv7e-m/fpu -lopencm3_stm32f4
+aes_256_ctr_m4.elf: LDFLAGS += -lopencm3_stm32f4
 aes_256_ctr_m4.elf: OBJS += $(COMMONDIR)/stm32f4_wrapper.o
-aes_256_ctr_m4.elf: $(COMMONDIR)/stm32f4_wrapper.o $(OPENCM3DIR)/lib/libopencm3_stm32f4.a
+aes_256_ctr_m4.elf: $(COMMONDIR)/stm32f4_wrapper.o
 
 aes_256_ctr_m3.%: ARCH_FLAGS = -mthumb -mcpu=cortex-m3 -msoft-float
 aes_256_ctr_m3.o: CFLAGS += -DSTM32L1
 $(COMMONDIR)/stm32l1_wrapper.o: CFLAGS += -DSTM32L1
 aes_256_ctr_m3.elf: LDSCRIPT = $(COMMONDIR)/stm32l100xc.ld
-aes_256_ctr_m3.elf: LDFLAGS += -L$(OPENCM3DIR)/lib/armv7-m -lopencm3_stm32l1
+aes_256_ctr_m3.elf: LDFLAGS += -lopencm3_stm32l1
 aes_256_ctr_m3.elf: OBJS += $(COMMONDIR)/stm32l1_wrapper.o
-aes_256_ctr_m3.elf: $(COMMONDIR)/stm32l1_wrapper.o $(OPENCM3DIR)/lib/libopencm3_stm32l1.a
+aes_256_ctr_m3.elf: $(COMMONDIR)/stm32l1_wrapper.o
 
 CFLAGS		+= -O3 \
 		   -Wall -Wextra -Wimplicit-function-declaration \

--- a/common/stm32f407x6.ld
+++ b/common/stm32f407x6.ld
@@ -35,4 +35,4 @@ MEMORY
 }
 
 /* Include the common ld script. */
-INCLUDE libopencm3_stm32f4.ld
+INCLUDE cortex-m-generic.ld

--- a/common/stm32f4_wrapper.c
+++ b/common/stm32f4_wrapper.c
@@ -18,7 +18,7 @@ const struct rcc_clock_scale myclock = {
 
 void clock_setup(void)
 {
-    rcc_clock_setup_hse_3v3(&myclock);
+    rcc_clock_setup_pll(&myclock);
     rcc_periph_clock_enable(RCC_GPIOA);
     rcc_periph_clock_enable(RCC_USART2);
     rcc_periph_clock_enable(RCC_CCMDATARAM);
@@ -47,8 +47,8 @@ void usart_setup(int baud)
 
 void flash_setup(void)
 {
-    FLASH_ACR |= FLASH_ACR_ICE;
-    FLASH_ACR |= FLASH_ACR_DCE;
+    FLASH_ACR |= FLASH_ACR_ICEN;
+    FLASH_ACR |= FLASH_ACR_DCEN;
     FLASH_ACR |= FLASH_ACR_PRFTEN;
 }
 

--- a/common/stm32l100xc.ld
+++ b/common/stm32l100xc.ld
@@ -28,5 +28,5 @@ MEMORY
 }
 
 /* Include the common ld script. */
-INCLUDE libopencm3_stm32l1.ld
+INCLUDE cortex-m-generic.ld
 

--- a/common/stm32wrapper.h
+++ b/common/stm32wrapper.h
@@ -4,10 +4,8 @@
 #include <libopencm3/stm32/rcc.h>
 #include <libopencm3/stm32/gpio.h>
 #include <libopencm3/stm32/usart.h>
-#include <libopencm3/cm3/nvic.h>
 #include <libopencm3/cm3/scs.h>
 #include <libopencm3/cm3/dwt.h>
-#include <libopencm3/stm32/dma.h>
 #include <libopencm3/stm32/flash.h>
 
 #ifdef NEEDS_RNG


### PR DESCRIPTION
There were some changes in libopencm3 that are not backwards-compatible regarding clock setup and flash setup:
- `FLASH_ACR_DCE` got renamed to `FLASH_ACR_DCEN`; `FLASH_ACR_ICE` got renamed to `FLASH_ACR_ICEN` in https://github.com/libopencm3/libopencm3/commit/6798cee2a53e9183c9202a5b3e6ee473c07d8470
- `rcc_clock_setup_hse_3v3` got deprecated in 
https://github.com/libopencm3/libopencm3/commit/ca6dcfbea137bd2145b4a7fbf24379f565f8280d


Also, the old version of libopencm3 that you used does not build with `make 4.3` due to the changes they made to the `+=` operator (https://lwn.net/Articles/810071/). 

I've made the necessary changes to make it compile again on my machine and with the most recent version of libopencm3. I've also added libopencm3 in a submodule, so that versioning is a bit easier. 